### PR TITLE
Add stats page showing rating history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@vite-pwa/astro": "^1.1.0",
         "astro": "^5.11.0",
+        "chart.js": "^4.5.0",
         "colorjs.io": "^0.5.2",
         "date-fns": "^4.1.0",
         "dexie": "^4.0.11",
@@ -2410,6 +2411,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -3777,6 +3784,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "@vite-pwa/astro": "^1.1.0",
     "astro": "^5.11.0",
+    "chart.js": "^4.5.0",
     "colorjs.io": "^0.5.2",
     "date-fns": "^4.1.0",
     "dexie": "^4.0.11",

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,0 +1,75 @@
+---
+import PageLayout from "../layouts/page-layout.astro";
+import Heading from "../components/heading.astro";
+---
+
+<PageLayout>
+  <Heading class="text-center">Stats</Heading>
+  <div class="grid gap-4">
+    <label class="grid gap-1 text-shadow-md">
+      Time range
+      <select id="range" class="rounded-xs py-2 px-4 border-4 border-dark shadow-lg">
+        <option value="7">Last week</option>
+        <option value="30">Last month</option>
+        <option value="183">Last 6 months</option>
+        <option value="365">Last year</option>
+      </select>
+    </label>
+    <canvas id="stats-chart" class="bg-dark rounded-md h-72"></canvas>
+  </div>
+</PageLayout>
+
+<script>
+  import { db } from "../utils/db";
+  import { Chart, registerables } from "chart.js";
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    Chart.register(...registerables);
+
+    const ctx = document.getElementById("stats-chart");
+    const range = document.getElementById("range");
+
+    const chart = new Chart(ctx, {
+      type: "line",
+      data: {
+        labels: [],
+        datasets: [
+          {
+            label: "Rating",
+            data: [],
+            borderColor: "currentColor",
+            backgroundColor: "currentColor",
+            fill: false,
+            tension: 0.3,
+          },
+        ],
+      },
+      options: {
+        scales: {
+          y: { min: 0, max: 10 },
+        },
+      },
+    });
+
+    async function refresh(days) {
+      const all = await db.ratings.toArray();
+      const threshold = new Date();
+      threshold.setDate(threshold.getDate() - days);
+
+      const data = all
+        .map((e) => ({ ...e, dateObj: new Date(e.date) }))
+        .filter((e) => e.dateObj >= threshold)
+        .sort((a, b) => a.dateObj - b.dateObj);
+
+      chart.data.labels = data.map((d) => d.dateObj.toLocaleDateString());
+      chart.data.datasets[0].data = data.map((d) => d.rating);
+      chart.update();
+    }
+
+    range.addEventListener("change", () => {
+      refresh(Number(range.value));
+    });
+
+    refresh(Number(range.value));
+  });
+</script>


### PR DESCRIPTION
## Summary
- install `chart.js`
- add new `/stats` page that displays mood rating history
- read saved ratings from IndexedDB with Dexie
- visualize ratings using Chart.js line chart with selectable time range

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68827682e724832b97b1051184930318